### PR TITLE
Remove superflous ocl constraint

### DIFF
--- a/bundles/tools.mdsd.modelingfoundations.identifier/model/identifier.ecore
+++ b/bundles/tools.mdsd.modelingfoundations.identifier/model/identifier.ecore
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
-    name="identifier" nsURI="http://www.mdsd.tools/modelingfoundations/identifier" nsPrefix="identifier">
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="identifier" nsURI="http://www.mdsd.tools/modelingfoundations/identifier"
+    nsPrefix="identifier">
   <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
     <details key="documentation" value="&lt;p>&#xA;Provides a package for uniquely identifiable elements&#xA;&lt;/p>"/>
-  </eAnnotations>
-  <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
-    <details key="invocationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
-    <details key="settingDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
-    <details key="validationDelegates" value="http://www.eclipse.org/emf/2002/Ecore/OCL"/>
   </eAnnotations>
   <eClassifiers xsi:type="ecore:EClass" name="Identifier" abstract="true">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
@@ -15,9 +11,6 @@
     </eAnnotations>
     <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore">
       <details key="constraints" value="identifierIsUnique"/>
-    </eAnnotations>
-    <eAnnotations source="http://www.eclipse.org/emf/2002/Ecore/OCL">
-      <details key="identifierIsUnique" value="Identifier.allInstances()->isUnique(p: Identifier | p.id)"/>
     </eAnnotations>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="id" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         iD="true">
@@ -30,8 +23,8 @@
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">
       <details key="documentation" value="The NamedElement meta class is inherited by all PCM classes whose instances bear a name. Thus, the semantic of &quot;bearing a name&quot; is given to all inheriting classes, so that the name can be used in visualisations, for example."/>
     </eAnnotations>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="entityName" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
-        defaultValueLiteral="aName"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="entityName" lowerBound="1"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" defaultValueLiteral="aName"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Entity" abstract="true" eSuperTypes="#//Identifier #//NamedElement">
     <eAnnotations source="http://www.eclipse.org/emf/2002/GenModel">

--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.4.4</version>
+		<version>0.5.5</version>
 	</parent>
 	<groupId>tools.mdsd.modelingfoundations</groupId>
-	<artifactId>parent</artifactId>	
-	<version>0.1.0-SNAPSHOT</version>
+	<artifactId>parent</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<properties>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.mdsd.modelingfoundations</groupId>
 		<artifactId>parent</artifactId>	
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>releng</artifactId>	
 	<packaging>pom</packaging>

--- a/releng/tools.mdsd.modelingfoundations.updatesite/pom.xml
+++ b/releng/tools.mdsd.modelingfoundations.updatesite/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.mdsd.modelingfoundations</groupId>
 		<artifactId>releng</artifactId>
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>tools.mdsd.modelingfoundations.updatesite</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>tools.mdsd.modelingfoundations</groupId>
 		<artifactId>parent</artifactId>	
-		<version>0.1.0-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>tests</artifactId>	
 	<packaging>pom</packaging>


### PR DESCRIPTION
* The uniqueness is checked by EMF, as the id field is configured to be used as identifier. We do not need OCL for that.
* Removed the OCL validation delegate, as it leads to very high performance impact on large models